### PR TITLE
fix: Resolve GitHub Actions release workflow ValidationError

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["examples/**"]
+  "ignore": ["frontend"]
 }


### PR DESCRIPTION
## Summary
• Fix changesets configuration to use actual package names instead of invalid glob patterns
• Resolves GitHub Actions release workflow failure with ValidationError

## Test plan
- [x] Verified changesets config validation passes locally
- [x] Tested `pnpm release` command executes successfully
- [x] Confirmed `svelte-langgraph` package publishes correctly while ignoring `frontend` example

🤖 Generated with [Claude Code](https://claude.ai/code)