### PR TITLE
Detect expiration refresh tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
       - run: "moon ci --color"
         env:
           PUBLIC_LANGGRAPH_API_URL: 'http://127.0.0.1:2024'
+          # Required for auth.ts env validation
+          AUTH_DESCOPE_ID: 'bogus_id'
+          AUTH_DESCOPE_SECRET: 'bogus_secret'
       - uses: moonrepo/run-report-action@v1
         if: success() || failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
       - run: "moon ci --color"
         env:
           PUBLIC_LANGGRAPH_API_URL: 'http://127.0.0.1:2024'
-          # Required for auth.ts env validation
-          AUTH_DESCOPE_ID: 'bogus_id'
-          AUTH_DESCOPE_SECRET: 'bogus_secret'
       - uses: moonrepo/run-report-action@v1
         if: success() || failure()
         with:

--- a/apps/frontend/src/auth.ts
+++ b/apps/frontend/src/auth.ts
@@ -43,16 +43,17 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 				} else {
 					console.info('Token expired, renewing', Date.now(), token.expires_at * 1000);
 
+					const clientId = env.AUTH_DESCOPE_ID;
+					const clientSecret = env.AUTH_DESCOPE_SECRET;
+
+					// Must check for required env vars to avoid type error at URLSearchParams.
+					if (!clientId || !clientSecret) {
+						throw new Error('Missing Descope client credentials');
+					}
+
 					try {
 						if (typeof token.refresh_token !== 'string')
 							throw new Error('Token has no refresh token.');
-
-						const clientId = env.AUTH_DESCOPE_ID;
-						const clientSecret = env.AUTH_DESCOPE_SECRET;
-
-						if (!clientId || !clientSecret) {
-							throw new Error('Missing Descope client credentials');
-						}
 
 						const response = await fetch('https://api.descope.com/oauth2/v1/token', {
 							headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/apps/frontend/src/auth.ts
+++ b/apps/frontend/src/auth.ts
@@ -10,6 +10,13 @@ declare module '@auth/sveltekit' {
 	}
 }
 
+const clientId = env.AUTH_DESCOPE_ID;
+const clientSecret = env.AUTH_DESCOPE_SECRET;
+
+if (!clientId || !clientSecret) {
+	throw new Error("Missing Descope client credentials");
+}
+
 export const { handle, signIn, signOut } = SvelteKitAuth({
 	providers: [Descope],
 	trustHost: true,
@@ -50,8 +57,8 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 						const response = await fetch('https://api.descope.com/oauth2/v1/token', {
 							headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 							body: new URLSearchParams({
-								client_id: env.AUTH_DESCOPE_ID,
-								client_secret: env.AUTH_DESCOPE_SECRET,
+								client_id: clientId,
+								client_secret: clientSecret,
 								grant_type: 'refresh_token',
 								refresh_token: token.refresh_token
 							}),

--- a/apps/frontend/src/auth.ts
+++ b/apps/frontend/src/auth.ts
@@ -47,7 +47,6 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 						if (typeof token.refresh_token !== 'string')
 							throw new Error('Token has no refresh token.');
 
-
 						const clientId = env.AUTH_DESCOPE_ID;
 						const clientSecret = env.AUTH_DESCOPE_SECRET;
 

--- a/apps/frontend/src/auth.ts
+++ b/apps/frontend/src/auth.ts
@@ -44,7 +44,7 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 					console.info('Token expired, renewing', Date.now(), token.expires_at * 1000);
 
 					try {
-						if (typeof token.refresh_token !== 'string') throw 'Token has no refresh token.';
+						if (typeof token.refresh_token !== 'string') throw new Error('Token has no refresh token.');
 
 						const response = await fetch('https://api.descope.com/oauth2/v1/token', {
 							headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/apps/frontend/src/auth.ts
+++ b/apps/frontend/src/auth.ts
@@ -10,13 +10,6 @@ declare module '@auth/sveltekit' {
 	}
 }
 
-const clientId = env.AUTH_DESCOPE_ID;
-const clientSecret = env.AUTH_DESCOPE_SECRET;
-
-if (!clientId || !clientSecret) {
-	throw new Error('Missing Descope client credentials');
-}
-
 export const { handle, signIn, signOut } = SvelteKitAuth({
 	providers: [Descope],
 	trustHost: true,
@@ -53,6 +46,14 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 					try {
 						if (typeof token.refresh_token !== 'string')
 							throw new Error('Token has no refresh token.');
+
+
+						const clientId = env.AUTH_DESCOPE_ID;
+						const clientSecret = env.AUTH_DESCOPE_SECRET;
+
+						if (!clientId || !clientSecret) {
+							throw new Error('Missing Descope client credentials');
+						}
 
 						const response = await fetch('https://api.descope.com/oauth2/v1/token', {
 							headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/apps/frontend/src/auth.ts
+++ b/apps/frontend/src/auth.ts
@@ -17,7 +17,6 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 			if ('access_token' in token) {
 				return { ...session, accessToken: token.access_token };
 			}
-			console.log('Returning session', session);
 			return session;
 		},
 		// Ref: https://docs.descope.com/getting-started/nextauth/functions

--- a/apps/frontend/src/auth.ts
+++ b/apps/frontend/src/auth.ts
@@ -14,7 +14,7 @@ const clientId = env.AUTH_DESCOPE_ID;
 const clientSecret = env.AUTH_DESCOPE_SECRET;
 
 if (!clientId || !clientSecret) {
-	throw new Error("Missing Descope client credentials");
+	throw new Error('Missing Descope client credentials');
 }
 
 export const { handle, signIn, signOut } = SvelteKitAuth({

--- a/apps/frontend/src/auth.ts
+++ b/apps/frontend/src/auth.ts
@@ -1,5 +1,6 @@
 import { SvelteKitAuth } from '@auth/sveltekit';
 import Descope from '@auth/sveltekit/providers/descope';
+import { env } from '$env/dynamic/private';
 
 // Add accessToken to Session type.
 // Ref: https://authjs.dev/getting-started/typescript#module-augmentation
@@ -13,17 +14,65 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 	providers: [Descope],
 	callbacks: {
 		session: async ({ session, token }) => {
-			if ('accessToken' in token) {
-				return { ...session, accessToken: token.accessToken };
+			if ('access_token' in token) {
+				return { ...session, accessToken: token.access_token };
 			}
+			console.log('Returning session', session);
 			return session;
 		},
-		jwt({ token, account }) {
+		// Ref: https://docs.descope.com/getting-started/nextauth/functions
+		jwt: async ({ token, account }) => {
 			if (account) {
-				// Add access token if provided.
-				return { ...token, accessToken: account.access_token };
+				console.info('Initial login');
+
+				if (account.expires_in === undefined) throw Error('Account has no expiration set.');
+
+				return {
+					...token,
+					access_token: account.access_token,
+					expires_at: Math.floor(Date.now() / 1000 + account.expires_in),
+					refresh_token: account.refresh_token
+				};
+			} else {
+				if (typeof token.expires_at !== 'number') throw Error('Token has no expiration set.');
+
+				if (Date.now() < token.expires_at * 1000) {
+					console.debug('Returning valid token');
+
+					return token;
+				} else {
+					console.info('Token expired, renewing', Date.now(), token.expires_at * 1000);
+
+					try {
+						if (typeof token.refresh_token !== 'string') throw 'Token has no refresh token.';
+
+						const response = await fetch('https://api.descope.com/oauth2/v1/token', {
+							headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+							body: new URLSearchParams({
+								client_id: env.AUTH_DESCOPE_ID,
+								client_secret: env.AUTH_DESCOPE_SECRET,
+								grant_type: 'refresh_token',
+								refresh_token: token.refresh_token
+							}),
+							method: 'POST'
+						});
+
+						const tokens = await response.json();
+
+						if (!response.ok) throw tokens;
+
+						return {
+							...token,
+							access_token: tokens.access_token,
+							expires_at: Math.floor(Date.now() / 1000 + tokens.expires_in),
+							refresh_token: tokens.refresh_token ?? token.refresh_token
+						};
+					} catch (error) {
+						console.error('Error refreshing access token', error);
+						return { ...token, error: 'RefreshAccessTokenError' };
+					}
+				}
 			}
-			return token;
 		}
 	}
 });

--- a/apps/frontend/src/auth.ts
+++ b/apps/frontend/src/auth.ts
@@ -43,7 +43,8 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 					console.info('Token expired, renewing', Date.now(), token.expires_at * 1000);
 
 					try {
-						if (typeof token.refresh_token !== 'string') throw new Error('Token has no refresh token.');
+						if (typeof token.refresh_token !== 'string')
+							throw new Error('Token has no refresh token.');
 
 						const response = await fetch('https://api.descope.com/oauth2/v1/token', {
 							headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/apps/frontend/src/lib/components/LoginModal.svelte
+++ b/apps/frontend/src/lib/components/LoginModal.svelte
@@ -24,7 +24,7 @@
 			Please sign in to continue.
 		</h3>
 		<SignIn provider="descope">
-			<Button slot="submitButton" size="sm">Sign in</Button>
+			<Button slot="submitButton" size="sm" tag="div">Sign in</Button>
 		</SignIn>
 	</div>
 </Modal>


### PR DESCRIPTION
So that we don't have to log out and log in again all the time. Also fixes an issue where the sign in `<button>` was already inside a `<button>` and hence caused hydration errors and possible inconsistencies.

Current implementation is provider-specific as for some reason this isn't part of Auth.js yet, ref: https://authjs.dev/guides/refresh-token-rotation?framework=Next.js

Alternative options would be:
1. Closer integration with Descope, using their web components. This will significantly limit potential applications of our FOSS app over generic OpenID Connect support.
2. Getting token refresh endpoint URL dynamically from issuer config.