### PR TITLE
Fix sign-in button label rendering in LoginModal

### DIFF
--- a/apps/frontend/src/lib/components/LoginModal.svelte
+++ b/apps/frontend/src/lib/components/LoginModal.svelte
@@ -25,7 +25,7 @@
 			{m.login_modal_message()}
 		</h3>
 		<SignIn provider="descope">
-			<Button slot="submitButton" size="sm" tag="div">{m.auth_sign_in}</Button>
+			<Button slot="submitButton" size="sm" tag="div">{m.auth_sign_in()}</Button>
 		</SignIn>
 	</div>
 </Modal>


### PR DESCRIPTION
Silly mistake - Changed the sign-in button label to call the translation function instead of referencing it, ensuring the correct text is displayed.