### PR TITLE
Use Python paths to import modules

### DIFF
--- a/apps/backend/langgraph.json
+++ b/apps/backend/langgraph.json
@@ -3,11 +3,11 @@
 		"."
 	],
 	"graphs": {
-		"chat": "./src/svelte_langgraph/graph.py:make_graph"
+		"chat": "svelte_langgraph.graph:make_graph"
 	},
 	"python_version": "3.13",
 	"env": ".env",
 	"auth": {
-		"path": "./src/svelte_langgraph/auth.py:auth"
+		"path": "svelte_langgraph.auth:auth"
 	}
 }


### PR DESCRIPTION
Prevents this error, both in (my) dev and production:
```
025-10-22T15:23:47.633321Z [error    ] Traceback (most recent call last):
  File "/Users/drbob/Development/svelte-langgraph/apps/backend/.venv/lib/python3.12/site-packages/starlette/routing.py", line 694, in lifespan
    async with self.lifespan_context(app) as maybe_state:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/drbob/.proto/tools/python/3.12.11/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/drbob/Development/svelte-langgraph/apps/backend/.venv/lib/python3.12/site-packages/langgraph_runtime_inmem/lifespan.py", line 80, in lifespan
    await graph.collect_graphs_from_env(True)
  File "/Users/drbob/Development/svelte-langgraph/apps/backend/.venv/lib/python3.12/site-packages/langgraph_api/graph.py", line 420, in collect_graphs_from_env
    graph = await run_in_executor(None, _graph_from_spec, spec)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/drbob/Development/svelte-langgraph/apps/backend/.venv/lib/python3.12/site-packages/langgraph_api/utils/config.py", line 144, in run_in_executor
    return await asyncio.get_running_loop().run_in_executor(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/drbob/.proto/tools/python/3.12.11/lib/python3.12/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/drbob/Development/svelte-langgraph/apps/backend/.venv/lib/python3.12/site-packages/langgraph_api/utils/config.py", line 135, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/drbob/Development/svelte-langgraph/apps/backend/.venv/lib/python3.12/site-packages/langgraph_api/graph.py", line 467, in _graph_from_spec
    modspec.loader.exec_module(module)  # type: ignore[possibly-unbound-attribute]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/Users/drbob/Development/svelte-langgraph/apps/backend/src/svelte_langgraph/graph.py", line 15, in <module>
    from .models import get_chat_model
ImportError: attempted relative import with no known parent package
Could not import python module for graph:
GraphSpec(id='chat', path='./src/svelte_langgraph/graph.py', module=None, variable='make_graph', config={}, description=None)
This error likely means you haven't installed your project and its dependencies yet. Before running the server, install your project:

If you are using requirements.txt:
python -m pip install -r requirements.txt

If you are using pyproject.toml or setuptools:
python -m pip install -e .

Make sure to run this command from your project's root directory (where your setup.py or pyproject.toml is located)
```