### PR TITLE
Migrate from Flowbite Icons to ShadDCN-lucide icons

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -62,6 +62,7 @@
 	},
 	"dependencies": {
 		"@sentry/sveltekit": "^10.0.0",
+		"lucide-svelte": "^0.555.0",
 		"mode-watcher": "^1.1.0"
 	},
 	"pnpm": {

--- a/apps/frontend/src/lib/components/AIMessageActions.svelte
+++ b/apps/frontend/src/lib/components/AIMessageActions.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
-	import { Button, Tooltip, Clipboard } from 'flowbite-svelte';
-	import { ArrowsRepeatOutline, CheckOutline, ClipboardCleanSolid } from 'flowbite-svelte-icons';
+	import { Button } from 'flowbite-svelte';
+	import { RefreshCw, Check, Clipboard } from 'lucide-svelte';
 	import type { BaseMessage } from '$lib/langgraph/types';
 	import * as m from '$lib/paraglide/messages.js';
+	import {
+		Tooltip,
+		TooltipTrigger,
+		TooltipContent,
+		TooltipProvider
+	} from '$lib/components/ui/tooltip/index.js';
+	import { Clipboard as Clipboard_icon } from 'flowbite-svelte';
 	import FeedbackButtons from './FeedbackButtons.svelte';
 
 	interface Props {
@@ -13,28 +20,50 @@
 	}
 
 	let { message, isHovered, onRegenerate, onFeedback }: Props = $props();
+	let copyOpen = $state(false);
 </script>
 
-<div
-	class="absolute bottom-2 left-0 flex items-center gap-1 transition-all duration-300 ease-in-out"
-	style="opacity: {isHovered ? '1' : '0'}; transform: translateY({isHovered ? '0' : '-4px'});"
->
-	<Clipboard value={message.text} embedded color="alternative" class="p-1.5!">
-		{#snippet children(success)}
-			<Tooltip isOpen={success}>{success ? m.message_copied() : m.message_copy()}</Tooltip>
-			{#if success}<CheckOutline size="xs" />{:else}<ClipboardCleanSolid size="xs" />{/if}
-		{/snippet}
-	</Clipboard>
-
-	<Button
-		onclick={() => onRegenerate?.(message)}
-		class="p-1.5!"
-		color="alternative"
-		size="xs"
-		title={m.message_regenerate()}
+<TooltipProvider>
+	<div
+		class="absolute bottom-2 left-0 flex items-center gap-1 transition-all duration-300 ease-in-out"
+		style="opacity: {isHovered ? '1' : '0'}; transform: translateY({isHovered ? '0' : '-4px'});"
 	>
-		<ArrowsRepeatOutline size="xs" />
-	</Button>
-	<Tooltip type="auto">{m.coming_soon()}</Tooltip>
-	<FeedbackButtons {message} {onFeedback} />
-</div>
+		<Tooltip open={copyOpen}>
+			<TooltipTrigger>
+				<Clipboard_icon
+					value={message.text}
+					embedded
+					color="alternative"
+					class="p-1.5!"
+					onchange={(e) =>
+						(copyOpen = (e.target as HTMLButtonElement).getAttribute('aria-pressed') === 'true')}
+				>
+					{#snippet children(success)}
+						{#if success}<Check class="h-3 w-3" />{:else}<Clipboard class="h-3 w-3" />{/if}
+					{/snippet}
+				</Clipboard_icon>
+			</TooltipTrigger>
+			<TooltipContent>
+				{copyOpen ? m.message_copied() : m.message_copy()}
+			</TooltipContent>
+		</Tooltip>
+
+		<Tooltip>
+			<TooltipTrigger>
+				<Button
+					onclick={() => onRegenerate?.(message)}
+					class="p-1.5!"
+					color="alternative"
+					size="xs"
+					title={m.message_regenerate()}
+				>
+					<RefreshCw class="h-3 w-3" />
+				</Button>
+			</TooltipTrigger>
+			<TooltipContent>
+				{m.coming_soon()}
+			</TooltipContent>
+		</Tooltip>
+		<FeedbackButtons {message} {onFeedback} />
+	</div>
+</TooltipProvider>

--- a/apps/frontend/src/lib/components/ChatErrorMessage.svelte
+++ b/apps/frontend/src/lib/components/ChatErrorMessage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { Card, Button } from 'flowbite-svelte';
-	import { ExclamationCircleOutline, RefreshOutline } from 'flowbite-svelte-icons';
 	import { m } from '$lib/paraglide/messages.js';
+	import { CircleAlert, RotateCw } from 'lucide-svelte';
 
 	interface Props {
 		error: Error;
@@ -16,7 +16,7 @@
 		<div
 			class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-rose-100 dark:bg-rose-950"
 		>
-			<ExclamationCircleOutline size="sm" class="text-rose-600 dark:text-rose-500" />
+			<CircleAlert class="h-4 w-4 text-rose-600 dark:text-rose-500" />
 		</div>
 		<div class="relative w-full">
 			<Card
@@ -28,7 +28,7 @@
 					</p>
 					<div class="flex gap-2 pt-1">
 						<Button size="sm" color="dark" outline onclick={onRetry}>
-							<RefreshOutline class="me-2 h-4 w-4" />
+							<RotateCw class="me-2 h-4 w-4" />
 							{m.chat_error_retry()}
 						</Button>
 					</div>

--- a/apps/frontend/src/lib/components/ChatMessage.svelte
+++ b/apps/frontend/src/lib/components/ChatMessage.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
 	import { Card } from 'flowbite-svelte';
-	import { UserOutline } from 'flowbite-svelte-icons';
 	import type { BaseMessage } from '$lib/langgraph/types';
 	import Markdown from 'svelte-exmarkdown';
 	import { gfmPlugin } from 'svelte-exmarkdown/gfm';
 	import AIMessageActions from './AIMessageActions.svelte';
 	import UserMessageActions from './UserMessageActions.svelte';
+	import { User } from 'lucide-svelte';
 
 	interface Props {
 		message: BaseMessage;
@@ -30,7 +30,7 @@
 		<div
 			class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gray-600 dark:bg-gray-400"
 		>
-			<UserOutline size="sm" class="text-white dark:text-gray-900" />
+			<User class="h-4 w-4 text-white dark:text-gray-900" />
 		</div>
 		<div class="relative w-full">
 			<div

--- a/apps/frontend/src/lib/components/ChatToolMessage.svelte
+++ b/apps/frontend/src/lib/components/ChatToolMessage.svelte
@@ -1,15 +1,8 @@
 <script lang="ts">
 	import type { ToolMessage } from '$lib/langgraph/types';
 	import * as m from '$lib/paraglide/messages.js';
-
-	import {
-		ToolsOutline,
-		CheckCircleOutline,
-		ExclamationCircleOutline,
-		ClockOutline,
-		AngleRightOutline
-	} from 'flowbite-svelte-icons';
 	import { slide } from 'svelte/transition';
+	import { ChevronRight, CircleAlert, CircleCheck, Clock, Wrench } from 'lucide-svelte';
 
 	interface Props {
 		message: ToolMessage;
@@ -24,7 +17,7 @@
 		<div
 			class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gray-500 dark:bg-gray-400"
 		>
-			<span><ToolsOutline size="sm" class="text-white dark:text-gray-900" /></span>
+			<span><Wrench class=" h-4 w-4 text-white dark:text-gray-900" /></span>
 		</div>
 		<div class="relative">
 			<button
@@ -37,14 +30,14 @@
 				<span class="font-mono text-xs text-gray-500 dark:text-gray-400">{message.tool_name}</span>
 
 				{#if message.status === 'success'}
-					<CheckCircleOutline size="sm" class="text-green-400 dark:text-green-400" />
+					<CircleCheck class="h-4 w-4 text-green-400 dark:text-green-400" />
 				{:else if message.status === 'error'}
-					<ExclamationCircleOutline size="sm" class="text-red-400 dark:text-red-400" />
+					<CircleAlert class="h-4 w-4 text-red-400 dark:text-red-400" />
 				{:else}
-					<ClockOutline size="sm" class="text-gray-400 dark:text-gray-400" />
+					<Clock class="h-3 w-3 text-gray-400 dark:text-gray-400" />
 				{/if}
 
-				<AngleRightOutline class="h-3 w-3" style={collapsed ? '' : 'transform: rotate(90deg)'} />
+				<ChevronRight class="h-3 w-3" style={collapsed ? '' : 'transform: rotate(90deg)'} />
 			</button>
 
 			{#if !collapsed}

--- a/apps/frontend/src/lib/components/ChatWaiting.svelte
+++ b/apps/frontend/src/lib/components/ChatWaiting.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { UserOutline } from 'flowbite-svelte-icons';
 	import { Spinner } from 'flowbite-svelte';
+	import { User } from 'lucide-svelte';
 </script>
 
 <div class="mb-6 flex w-full justify-start">
@@ -8,7 +8,7 @@
 		<div
 			class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gray-600 dark:bg-gray-400"
 		>
-			<UserOutline size="sm" class="text-white dark:text-gray-900" />
+			<User class="h-3 w-3 text-white dark:text-gray-900" />
 		</div>
 		<div class="relative w-full">
 			<Spinner />

--- a/apps/frontend/src/lib/components/FeedbackButtons.svelte
+++ b/apps/frontend/src/lib/components/FeedbackButtons.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { Button, Tooltip } from 'flowbite-svelte';
-	import { ThumbsUpOutline, ThumbsDownOutline } from 'flowbite-svelte-icons';
+
 	import type { BaseMessage } from '$lib/langgraph/types';
 	import * as m from '$lib/paraglide/messages.js';
+	import { ThumbsDown, ThumbsUp } from 'lucide-svelte';
 
 	interface Props {
 		message: BaseMessage;
@@ -27,7 +28,7 @@
 		size="xs"
 		title={m.message_feedback_good()}
 	>
-		<ThumbsUpOutline size="xs" />
+		<ThumbsUp class="h-3 w-3" />
 	</Button>
 	<Tooltip type="auto">Coming Soon !</Tooltip>
 	<Button
@@ -37,7 +38,7 @@
 		size="xs"
 		title={m.message_feedback_bad()}
 	>
-		<ThumbsDownOutline size="xs" />
+		<ThumbsDown class="h-3 w-3" />
 	</Button>
 	<Tooltip type="auto">Coming Soon !</Tooltip>
 </div>

--- a/apps/frontend/src/lib/components/LanguageSwitcher.svelte
+++ b/apps/frontend/src/lib/components/LanguageSwitcher.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { getLocale, setLocale, locales, type Locale } from '$lib/paraglide/runtime.js';
 	import { Button, Dropdown, DropdownItem } from 'flowbite-svelte';
-	import { GlobeOutline } from 'flowbite-svelte-icons';
 	import { m } from '$lib/paraglide/messages.js';
+	import { Globe } from 'lucide-svelte';
 
 	let { class: className = '' } = $props();
 
@@ -17,7 +17,7 @@
 </script>
 
 <Button class={className} color="light" outline={false}>
-	<GlobeOutline />
+	<Globe class="h-5 w-5" />
 </Button>
 <Dropdown simple>
 	{#each locales as localeCode (localeCode)}

--- a/apps/frontend/src/lib/components/LoginModal.svelte
+++ b/apps/frontend/src/lib/components/LoginModal.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { Modal } from 'flowbite-svelte';
-	import { ExclamationCircleOutline } from 'flowbite-svelte-icons';
 	import * as m from '$lib/paraglide/messages.js';
 	import SignInButton from '$lib/auth/components/SignInButton.svelte';
+	import { CircleAlert } from 'lucide-svelte';
 
 	interface Props {
 		open: boolean;
@@ -20,7 +20,7 @@
 
 <Modal title={m.login_modal_title()} size="xs" bind:open onclose={handleClose}>
 	<div class="text-center">
-		<ExclamationCircleOutline class="mx-auto mb-4 h-12 w-12 text-gray-400 dark:text-gray-200" />
+		<CircleAlert class="mx-auto mb-4 h-12 w-12 text-gray-400 dark:text-gray-200" />
 		<h3 class="mb-5 text-lg font-normal text-gray-500 dark:text-gray-400">
 			{m.login_modal_message()}
 		</h3>

--- a/apps/frontend/src/lib/components/SubmitButton.svelte
+++ b/apps/frontend/src/lib/components/SubmitButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Button, Spinner } from 'flowbite-svelte';
-	import { PaperPlaneSolid } from 'flowbite-svelte-icons';
+	import { Send } from 'lucide-svelte';
 
 	interface Props {
 		isStreaming: boolean;
@@ -19,6 +19,6 @@
 	{#if isStreaming}
 		<Spinner />
 	{:else}
-		<PaperPlaneSolid class="h-4 w-4 translate-x-px -translate-y-px rotate-45" />
+		<Send class="h-4 w-4  translate-y-px " />
 	{/if}
 </Button>

--- a/apps/frontend/src/lib/components/UserMessageActions.svelte
+++ b/apps/frontend/src/lib/components/UserMessageActions.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { Button, Tooltip } from 'flowbite-svelte';
-	import { PenOutline } from 'flowbite-svelte-icons';
 	import type { BaseMessage } from '$lib/langgraph/types';
 	import * as m from '$lib/paraglide/messages.js';
+	import { Pencil } from 'lucide-svelte';
 
 	interface Props {
 		message: BaseMessage;
@@ -24,7 +24,7 @@
 		size="xs"
 		title={m.message_edit()}
 	>
-		<PenOutline size="xs" />
+		<Pencil class="h-3 w-3" />
 	</Button>
 	<Tooltip type="auto">{m.coming_soon()}</Tooltip>
 </div>

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -1,16 +1,9 @@
 <script lang="ts">
 	import '../app.tailwind.css';
-
 	import { SignOut } from '@auth/sveltekit/components';
 	import { page } from '$app/state';
 	import { m } from '$lib/paraglide/messages.js';
-
-	import {
-		ArrowLeftToBracketOutline,
-		MessagesOutline,
-		MoonSolid,
-		SunSolid
-	} from 'flowbite-svelte-icons';
+	import { LogOut, MessagesSquare, Moon, Sun } from 'lucide-svelte';
 	import {
 		Button,
 		Navbar,
@@ -25,7 +18,6 @@
 	} from 'flowbite-svelte';
 
 	import { ModeWatcher, toggleMode, mode } from 'mode-watcher';
-
 	import LanguageSwitcher from '$lib/components/LanguageSwitcher.svelte';
 	import SignInButton from '$lib/auth/components/SignInButton.svelte';
 
@@ -35,12 +27,11 @@
 <ModeWatcher />
 <Navbar>
 	<NavBrand href="/">
-		<MessagesOutline class="me-3 h-6 sm:h-9" />
+		<MessagesSquare class="me-3 h-6 sm:h-9" />
 		<span class="self-center text-xl font-semibold whitespace-nowrap dark:text-white">
 			{m.app_title()}
 		</span>
 	</NavBrand>
-
 	<div class="flex items-center md:order-2">
 		{#if page.data.session}
 			<!-- Avatar Button -->
@@ -75,9 +66,9 @@
 				>
 					<span>{mode.current === 'light' ? m.light_mode() : m.dark_mode()}</span>
 					{#if mode.current === 'light'}
-						<SunSolid class="text-primary-500 h-5 w-5" />
+						<Sun class="text-primary-500 h-5 w-5" />
 					{:else}
-						<MoonSolid class="text-primary-600 h-5 w-5" />
+						<Moon class="text-primary-600 h-5 w-5" />
 					{/if}
 				</button>
 				<DropdownDivider />
@@ -93,7 +84,7 @@
 						class="flex w-full items-center justify-between px-4 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-600"
 					>
 						<span>{m.auth_sign_out()}</span>
-						<ArrowLeftToBracketOutline
+						<LogOut
 							class="text-primary-500 dark:text-primary-600 pointer-events-none h-5 w-5 shrink-0"
 						/>
 					</div>
@@ -111,5 +102,4 @@
 		<NavLi href="/chat">{m.nav_chat()}</NavLi>
 	</NavUl>
 </Navbar>
-
 {@render children()}

--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -1,8 +1,8 @@
 <script>
 	import { Section, News, HeroHeader, HeroBody } from 'flowbite-svelte-blocks';
 	import { Button } from 'flowbite-svelte';
-	import { ArrowRightOutline, VideoCameraSolid } from 'flowbite-svelte-icons';
 	import * as m from '$lib/paraglide/messages.js';
+	import { ArrowRight, Video } from 'lucide-svelte';
 </script>
 
 <Section name="heroDefault">
@@ -24,12 +24,12 @@
 		<a href="/chat">
 			<Button size="lg" color="red">
 				{m.landing_cta_get_started()}
-				<ArrowRightOutline size="md" class="-mr-1 ml-2" />
+				<ArrowRight class="-mr-1 ml-2 h-5 w-5" />
 			</Button>
 		</a>
 		<a href="/">
 			<Button size="lg" color="light">
-				<VideoCameraSolid size="xs" class="mr-2 -ml-1" />
+				<Video class="mr-2 -ml-1 h-3 w-3" />
 				{m.landing_cta_watch_video()}
 			</Button>
 		</a>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       '@sentry/sveltekit':
         specifier: ^10.0.0
         version: 10.0.0(@sveltejs/kit@2.25.2(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.36.14)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.30.1)))(svelte@5.36.14)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.30.1)))(svelte@5.36.14)(vite@6.3.5(@types/node@24.1.0)(jiti@2.5.0)(lightningcss@1.30.1))
+      lucide-svelte:
+        specifier: ^0.555.0
+        version: 0.555.0(svelte@5.36.14)
       mode-watcher:
         specifier: ^1.1.0
         version: 1.1.0(svelte@5.36.14)
@@ -2336,6 +2339,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-svelte@0.555.0:
+    resolution: {integrity: sha512-2kWIcstKGgQObLGpYXmcYwm/Y83Am+AQcP7MnybrmaRU1+QUJ/WSEpv/wAbwaSkrWUiN1TX/9FuWQKLeEeWCrQ==}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5.0.0-next.42
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -5665,6 +5673,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-svelte@0.555.0(svelte@5.36.14):
+    dependencies:
+      svelte: 5.36.14
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
To guide towards a renewed PR/manual conflict resolution of #141. This includes all the work on icon commits but leaves out avatar stuff. It also squashed all commits into a single commit and applied formatting.

I tried manually merging migrate-button-component-slg-55 but, as can be seen below, many merge conflicts ensued.

@shkelqim627 You are cordially invited to manually apply changes from https://github.com/synergyai-nl/svelte-langgraph/pull/155/commits/47aa4c583b477fbe0b0625782d6737f368729c31 off a brand new fork off the base branch _leaving out_ unrelated changes such as classes on buttons and the tooltip (those will come later). 