### PR TITLE
Fix LangGraph graph factory function signature

### DIFF
--- a/apps/backend/src/svelte_langgraph/graph.py
+++ b/apps/backend/src/svelte_langgraph/graph.py
@@ -54,14 +54,12 @@ def get_prompt(state: AgentState, config: RunnableConfig) -> Sequence[BaseMessag
     )
 
 
-def make_graph(
-    config: RunnableConfig,
-    weather_tool: WeatherToolType | None = None,
-) -> CompiledStateGraph:
+def make_graph(config: RunnableConfig) -> CompiledStateGraph:
     model = get_chat_model()
     checkpointer = get_checkpointer()
 
-    tool = weather_tool if weather_tool is not None else get_weather
+    # Get weather tool from config if provided, otherwise use default
+    tool = config.get("configurable", {}).get("weather_tool", get_weather)
 
     agent = create_react_agent(
         model=model,

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -133,7 +133,8 @@ async def agent(thread_config: RunnableConfig):
     Uses the local get_weather mock instead of the real get_weather to avoid
     the random 1-10 second sleep in the real implementation.
     """
-    return make_graph(thread_config, weather_tool=get_weather)
+    thread_config["configurable"]["weather_tool"] = get_weather
+    return make_graph(thread_config)
 
 
 @pytest.fixture


### PR DESCRIPTION
LangGraph requires the factory function to accept only a RunnableConfig parameter. Updated make_graph to accept only config and pass the `weather_tool` through the config's configurable dict instead.

  - Remove weather_tool parameter from make_graph function signature
  - Pass weather_tool through config["configurable"] dict
  - Update test fixture to inject weather_tool through config