### PR TITLE
Implement edit functionality for user messages 2 slg 28

### DIFF
--- a/apps/frontend/messages/en.json
+++ b/apps/frontend/messages/en.json
@@ -50,5 +50,7 @@
 	"message_edit": "Edit",
 	"message_copied": "Copied",
 	"chat_error_retry": "Retry",
-	"coming_soon": "Coming Soon!"
+	"coming_soon": "Coming Soon!",
+	"cancel": "Cancel",
+	"save_and_send": "Save & Send"
 }

--- a/apps/frontend/messages/hi.json
+++ b/apps/frontend/messages/hi.json
@@ -50,5 +50,7 @@
 	"tool_result": "परिणाम:",
 	"message_copied": "प्रतिलिपि हो गई",
 	"chat_error_retry": "पुनः प्रयास करें",
-	"coming_soon": "जल्द आ रहा है!"
+	"coming_soon": "जल्द आ रहा है!",
+	"cancel": "रद्द करें",
+	"save_and_send": "सहेजें और भेजें"
 }

--- a/apps/frontend/messages/nl.json
+++ b/apps/frontend/messages/nl.json
@@ -50,5 +50,7 @@
 	"light_mode": "Lichte modus",
 	"message_copied": "Gekopieerd",
 	"chat_error_retry": "Opnieuw proberen",
-	"coming_soon": "Binnenkort beschikbaar!"
+	"coming_soon": "Binnenkort beschikbaar!",
+	"cancel": "Annuleren",
+	"save_and_send": "Opslaan & Verzenden"
 }

--- a/apps/frontend/src/lib/components/Chat.svelte
+++ b/apps/frontend/src/lib/components/Chat.svelte
@@ -120,6 +120,7 @@
 		const parentCheckpoint = meta?.firstSeenState?.parent_checkpoint;
 
 		// Snapshot AI count so final_answer_started tracks the new response correctly
+		last_user_message = newText; // keep retry in sync with the edited prompt
 		aiMessageCountAtSubmit = messages.filter((m) => m.type === 'ai').length;
 		stream.submit(
 			{ messages: [{ type: 'human', content: newText }] },

--- a/apps/frontend/src/lib/components/Chat.svelte
+++ b/apps/frontend/src/lib/components/Chat.svelte
@@ -108,12 +108,12 @@
 		stream.stop();
 	}
 
-	function handleEdit(message: Message, newText: string) {
-		if (stream.isLoading) return;
+	function handleEdit(message: Message, newText: string): boolean {
+		if (stream.isLoading) return false;
 
 		// Match converted message back to the raw BaseMessage instance for metadata lookup
 		const rawMsg = stream.messages.find((m) => m.id === message.id);
-		if (!rawMsg) return;
+		if (!rawMsg) return false;
 
 		// Submit against the parent checkpoint to branch from before this message
 		const meta = stream.getMessagesMetadata(rawMsg);
@@ -126,6 +126,7 @@
 			{ messages: [{ type: 'human', content: newText }] },
 			{ checkpoint: parentCheckpoint }
 		);
+		return true;
 	}
 </script>
 

--- a/apps/frontend/src/lib/components/Chat.svelte
+++ b/apps/frontend/src/lib/components/Chat.svelte
@@ -110,10 +110,9 @@
 
 	function handleEdit(message: Message, newText: string) {
 		if (stream.isLoading) return;
-		const rawMsg = stream.messages.find((m) => (m as unknown as { id?: string }).id === message.id);
+		const rawMsg = stream.messages.find((m) => m.id === message.id);
 		if (!rawMsg) return;
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const meta = (stream as any).getMessagesMetadata?.(rawMsg);
+		const meta = stream.getMessagesMetadata(rawMsg);
 		const parentCheckpoint = meta?.firstSeenState?.parent_checkpoint;
 		aiMessageCountAtSubmit = messages.filter((m) => m.type === 'ai').length;
 		stream.submit(

--- a/apps/frontend/src/lib/components/Chat.svelte
+++ b/apps/frontend/src/lib/components/Chat.svelte
@@ -107,6 +107,20 @@
 	function stopGeneration() {
 		stream.stop();
 	}
+
+	function handleEdit(message: Message, newText: string) {
+		if (stream.isLoading) return;
+		const rawMsg = stream.messages.find((m) => (m as unknown as { id?: string }).id === message.id);
+		if (!rawMsg) return;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const meta = (stream as any).getMessagesMetadata?.(rawMsg);
+		const parentCheckpoint = meta?.firstSeenState?.parent_checkpoint;
+		aiMessageCountAtSubmit = messages.filter((m) => m.type === 'ai').length;
+		stream.submit(
+			{ messages: [{ type: 'human', content: newText }] },
+			{ checkpoint: parentCheckpoint }
+		);
+	}
 </script>
 
 <div class="flex h-[calc(100vh-4rem)] flex-col">
@@ -124,6 +138,7 @@
 				finalAnswerStarted={final_answer_started}
 				{generationError}
 				onRetryError={retryGeneration}
+				onEdit={handleEdit}
 			/>
 		{/if}
 	</div>

--- a/apps/frontend/src/lib/components/Chat.svelte
+++ b/apps/frontend/src/lib/components/Chat.svelte
@@ -110,10 +110,16 @@
 
 	function handleEdit(message: Message, newText: string) {
 		if (stream.isLoading) return;
+
+		// Match converted message back to the raw BaseMessage instance for metadata lookup
 		const rawMsg = stream.messages.find((m) => m.id === message.id);
 		if (!rawMsg) return;
+
+		// Submit against the parent checkpoint to branch from before this message
 		const meta = stream.getMessagesMetadata(rawMsg);
 		const parentCheckpoint = meta?.firstSeenState?.parent_checkpoint;
+
+		// Snapshot AI count so final_answer_started tracks the new response correctly
 		aiMessageCountAtSubmit = messages.filter((m) => m.type === 'ai').length;
 		stream.submit(
 			{ messages: [{ type: 'human', content: newText }] },

--- a/apps/frontend/src/lib/components/Chat.svelte.test.ts
+++ b/apps/frontend/src/lib/components/Chat.svelte.test.ts
@@ -236,6 +236,67 @@ describe('Chat', () => {
 		});
 	});
 
+	describe('when a user message is edited', () => {
+		test('shows a textarea when the edit button is hovered and clicked', async () => {
+			const user = userEvent.setup();
+			mockModule.setMessages([{ type: 'human', content: 'Original message', id: 'user-1' }]);
+
+			renderChat();
+
+			const messageCard = await screen.findByText('Original message');
+			await user.hover(messageCard);
+
+			const editButton = await screen.findByTitle(/edit/i);
+			await user.click(editButton);
+
+			const textarea = screen.getByDisplayValue('Original message');
+			expect(textarea).toBeInTheDocument();
+		});
+
+		test('pressing Escape cancels editing and restores the message', async () => {
+			const user = userEvent.setup();
+			mockModule.setMessages([{ type: 'human', content: 'Original message', id: 'user-1' }]);
+
+			renderChat();
+
+			const messageCard = await screen.findByText('Original message');
+			await user.hover(messageCard);
+			await user.click(await screen.findByTitle(/edit/i));
+
+			await user.keyboard('{Escape}');
+
+			expect(screen.queryByDisplayValue('Original message')).not.toBeInTheDocument();
+			expect(screen.getByText('Original message')).toBeInTheDocument();
+		});
+
+		test('submits edited message with parent checkpoint on Enter', async () => {
+			const user = userEvent.setup();
+			const mockSubmit = vi.fn();
+			const mockGetMetadata = vi.fn().mockReturnValue({
+				firstSeenState: { parent_checkpoint: { id: 'checkpoint-1' } }
+			});
+			mockModule.mockStreamCallbacks.submit = mockSubmit;
+			mockModule.mockStreamCallbacks.getMessagesMetadata = mockGetMetadata;
+			mockModule.setMessages([{ type: 'human', content: 'Original message', id: 'user-1' }]);
+
+			renderChat();
+
+			const messageCard = await screen.findByText('Original message');
+			await user.hover(messageCard);
+			await user.click(await screen.findByTitle(/edit/i));
+
+			const textarea = screen.getByDisplayValue('Original message');
+			await user.clear(textarea);
+			await user.type(textarea, 'Edited message');
+			await user.keyboard('{Enter}');
+
+			expect(mockSubmit).toHaveBeenCalledWith(
+				{ messages: [{ type: 'human', content: 'Edited message' }] },
+				{ checkpoint: { id: 'checkpoint-1' } }
+			);
+		});
+	});
+
 	describe('when stream errors before any messages arrive', () => {
 		test('shows the error instead of the suggestions screen', async () => {
 			mockModule.setError(new Error('Connection failed'));

--- a/apps/frontend/src/lib/components/ChatInput.svelte
+++ b/apps/frontend/src/lib/components/ChatInput.svelte
@@ -21,7 +21,7 @@
 
 	let isEmpty = $derived(!(value ?? '').trim());
 	function handleKeyPress(event: KeyboardEvent) {
-		if (event.key === 'Enter' && event.shiftKey === false) {
+		if (event.key === 'Enter' && event.shiftKey === false && !event.isComposing) {
 			event.preventDefault();
 			if (!isEmpty && !isStreaming) {
 				onSubmit();

--- a/apps/frontend/src/lib/components/ChatMessage.svelte
+++ b/apps/frontend/src/lib/components/ChatMessage.svelte
@@ -6,10 +6,11 @@
 	import { gfmPlugin } from 'svelte-exmarkdown/gfm';
 	import AIMessageActions from './AIMessageActions.svelte';
 	import UserMessageActions from './UserMessageActions.svelte';
+	import UserMessageEdit from './UserMessageEdit.svelte';
 
 	interface Props {
 		message: BaseMessage;
-		onEdit?: (message: BaseMessage) => void;
+		onEdit?: (message: BaseMessage, newText: string) => void;
 		onRegenerate?: (message: BaseMessage) => void;
 		onFeedback?: (message: BaseMessage, type: 'up' | 'down') => void;
 	}
@@ -19,6 +20,35 @@
 	const plugins = [gfmPlugin()];
 
 	let isHovered = $state(false);
+	let isEditing = $state(false);
+	let editText = $state('');
+	let textareaEl: HTMLTextAreaElement | undefined = $state();
+
+	$effect(() => {
+		if (isEditing && textareaEl) {
+			textareaEl.focus();
+			textareaEl.select();
+		}
+	});
+
+	function startEditing() {
+		editText = message.text;
+		isEditing = true;
+	}
+
+	function cancelEditing() {
+		isEditing = false;
+	}
+
+	function confirmEdit() {
+		const trimmed = editText.trim();
+		isEditing = false;
+		if (trimmed && trimmed !== message.text) {
+			onEdit?.(message, trimmed);
+		}
+	}
+
+	let rows = $derived(Math.max(2, editText.split('\n').length));
 </script>
 
 <div class="mb-6 w-full {message.type === 'user' ? 'flex justify-end' : 'flex justify-start'}">
@@ -31,30 +61,40 @@
 			<User size={20} class="text-foreground" />
 		</div>
 		<div class="relative w-full">
-			<div
-				role="group"
-				onmouseenter={() => (isHovered = true)}
-				onmouseleave={() => (isHovered = false)}
-				class="relative w-full"
-			>
-				{#if message.type === 'ai'}
-					<Card.Root class="border-border-card bg-muted border shadow-sm">
-						<Card.Content class="prose prose-gray dark:prose-invert max-w-none text-sm">
-							<Markdown md={message.text} {plugins} />
-						</Card.Content>
-					</Card.Root>
-					<AIMessageActions {message} {isHovered} {onRegenerate} {onFeedback} />
-				{:else}
-					<Card.Root class="bg-foreground border-0 shadow-sm">
-						<Card.Content
-							class="prose prose-invert text-background max-w-none text-sm whitespace-pre-wrap"
-						>
-							{message.text}
-						</Card.Content>
-					</Card.Root>
-					<UserMessageActions {message} {isHovered} {onEdit} />
-				{/if}
-			</div>
+			{#if message.type === 'user' && isEditing}
+				<UserMessageEdit
+					bind:value={editText}
+					bind:textareaRef={textareaEl}
+					{rows}
+					onConfirm={confirmEdit}
+					onCancel={cancelEditing}
+				/>
+			{:else}
+				<div
+					role="group"
+					onmouseenter={() => (isHovered = true)}
+					onmouseleave={() => (isHovered = false)}
+					class="relative w-full"
+				>
+					{#if message.type === 'ai'}
+						<Card.Root class="border-border-card bg-muted border shadow-sm">
+							<Card.Content class="prose prose-gray dark:prose-invert max-w-none text-sm">
+								<Markdown md={message.text} {plugins} />
+							</Card.Content>
+						</Card.Root>
+						<AIMessageActions {message} {isHovered} {onRegenerate} {onFeedback} />
+					{:else}
+						<Card.Root class="bg-foreground border-0 shadow-sm">
+							<Card.Content
+								class="prose prose-invert text-background max-w-none text-sm whitespace-pre-wrap"
+							>
+								{message.text}
+							</Card.Content>
+						</Card.Root>
+						<UserMessageActions {isHovered} onEdit={startEditing} />
+					{/if}
+				</div>
+			{/if}
 		</div>
 	</div>
 </div>

--- a/apps/frontend/src/lib/components/ChatMessage.svelte
+++ b/apps/frontend/src/lib/components/ChatMessage.svelte
@@ -33,10 +33,9 @@
 	}
 
 	function confirmEdit() {
-		const trimmed = editText.trim();
 		isEditing = false;
-		if (trimmed && trimmed !== message.text) {
-			onEdit(message, trimmed);
+		if (editText.trim() && editText !== message.text) {
+			onEdit(message, editText);
 		}
 	}
 </script>

--- a/apps/frontend/src/lib/components/ChatMessage.svelte
+++ b/apps/frontend/src/lib/components/ChatMessage.svelte
@@ -10,7 +10,7 @@
 
 	interface Props {
 		message: BaseMessage;
-		onEdit?: (message: BaseMessage, newText: string) => void;
+		onEdit: (message: BaseMessage, newText: string) => void;
 		onRegenerate?: (message: BaseMessage) => void;
 		onFeedback?: (message: BaseMessage, type: 'up' | 'down') => void;
 	}
@@ -44,7 +44,7 @@
 		const trimmed = editText.trim();
 		isEditing = false;
 		if (trimmed && trimmed !== message.text) {
-			onEdit?.(message, trimmed);
+			onEdit(message, trimmed);
 		}
 	}
 

--- a/apps/frontend/src/lib/components/ChatMessage.svelte
+++ b/apps/frontend/src/lib/components/ChatMessage.svelte
@@ -22,14 +22,6 @@
 	let isHovered = $state(false);
 	let isEditing = $state(false);
 	let editText = $state('');
-	let textareaEl: HTMLTextAreaElement | undefined = $state();
-
-	$effect(() => {
-		if (isEditing && textareaEl) {
-			textareaEl.focus();
-			textareaEl.select();
-		}
-	});
 
 	function startEditing() {
 		editText = message.text;
@@ -48,7 +40,6 @@
 		}
 	}
 
-	let rows = $derived(Math.max(2, editText.split('\n').length));
 </script>
 
 <div class="mb-6 w-full {message.type === 'user' ? 'flex justify-end' : 'flex justify-start'}">
@@ -64,8 +55,6 @@
 			{#if message.type === 'user' && isEditing}
 				<UserMessageEdit
 					bind:value={editText}
-					bind:textareaRef={textareaEl}
-					{rows}
 					onConfirm={confirmEdit}
 					onCancel={cancelEditing}
 				/>

--- a/apps/frontend/src/lib/components/ChatMessage.svelte
+++ b/apps/frontend/src/lib/components/ChatMessage.svelte
@@ -10,7 +10,7 @@
 
 	interface Props {
 		message: BaseMessage;
-		onEdit: (message: BaseMessage, newText: string) => void;
+		onEdit: (message: BaseMessage, newText: string) => boolean;
 		onRegenerate?: (message: BaseMessage) => void;
 		onFeedback?: (message: BaseMessage, type: 'up' | 'down') => void;
 	}
@@ -33,9 +33,13 @@
 	}
 
 	function confirmEdit() {
-		isEditing = false;
 		if (editText.trim() && editText !== message.text) {
-			onEdit(message, editText);
+			// Only close the editor if the edit was accepted (rejected when a run is streaming)
+			if (onEdit(message, editText)) {
+				isEditing = false;
+			}
+		} else {
+			isEditing = false;
 		}
 	}
 </script>

--- a/apps/frontend/src/lib/components/ChatMessage.svelte
+++ b/apps/frontend/src/lib/components/ChatMessage.svelte
@@ -39,7 +39,6 @@
 			onEdit(message, trimmed);
 		}
 	}
-
 </script>
 
 <div class="mb-6 w-full {message.type === 'user' ? 'flex justify-end' : 'flex justify-start'}">
@@ -53,11 +52,7 @@
 		</div>
 		<div class="relative w-full">
 			{#if message.type === 'user' && isEditing}
-				<UserMessageEdit
-					bind:value={editText}
-					onConfirm={confirmEdit}
-					onCancel={cancelEditing}
-				/>
+				<UserMessageEdit bind:value={editText} onConfirm={confirmEdit} onCancel={cancelEditing} />
 			{:else}
 				<div
 					role="group"

--- a/apps/frontend/src/lib/components/ChatMessages.svelte
+++ b/apps/frontend/src/lib/components/ChatMessages.svelte
@@ -12,7 +12,7 @@
 		finalAnswerStarted: boolean;
 		generationError?: Error | null;
 		onRetryError?: () => void;
-		onEdit?: (message: Message, newText: string) => void;
+		onEdit: (message: Message, newText: string) => void;
 	}
 
 	let {
@@ -31,7 +31,7 @@
 				{#if message.type === 'tool'}
 					<ChatToolMessage {message} />
 				{:else if message.text}
-					<ChatMessage {message} onEdit={(msg, newText) => onEdit?.(msg as Message, newText)} />
+					<ChatMessage {message} onEdit={(msg, newText) => onEdit(msg as Message, newText)} />
 				{/if}
 			</div>
 		{/each}

--- a/apps/frontend/src/lib/components/ChatMessages.svelte
+++ b/apps/frontend/src/lib/components/ChatMessages.svelte
@@ -12,9 +12,16 @@
 		finalAnswerStarted: boolean;
 		generationError?: Error | null;
 		onRetryError?: () => void;
+		onEdit?: (message: Message, newText: string) => void;
 	}
 
-	let { messages = [], finalAnswerStarted, generationError = null, onRetryError }: Props = $props();
+	let {
+		messages = [],
+		finalAnswerStarted,
+		generationError = null,
+		onRetryError,
+		onEdit
+	}: Props = $props();
 </script>
 
 <ScrollableContainer>
@@ -24,7 +31,7 @@
 				{#if message.type === 'tool'}
 					<ChatToolMessage {message} />
 				{:else if message.text}
-					<ChatMessage {message} />
+					<ChatMessage {message} onEdit={(msg, newText) => onEdit?.(msg as Message, newText)} />
 				{/if}
 			</div>
 		{/each}

--- a/apps/frontend/src/lib/components/ChatMessages.svelte
+++ b/apps/frontend/src/lib/components/ChatMessages.svelte
@@ -12,7 +12,7 @@
 		finalAnswerStarted: boolean;
 		generationError?: Error | null;
 		onRetryError?: () => void;
-		onEdit: (message: Message, newText: string) => void;
+		onEdit: (message: Message, newText: string) => boolean;
 	}
 
 	let {

--- a/apps/frontend/src/lib/components/ChatMessages.svelte.test.ts
+++ b/apps/frontend/src/lib/components/ChatMessages.svelte.test.ts
@@ -8,6 +8,7 @@ function renderMessages(overrides: Record<string, unknown> = {}) {
 	return renderWithProviders(ChatMessages, {
 		messages: [],
 		finalAnswerStarted: true,
+		onEdit: vi.fn(),
 		...overrides
 	});
 }

--- a/apps/frontend/src/lib/components/UserMessageActions.svelte
+++ b/apps/frontend/src/lib/components/UserMessageActions.svelte
@@ -6,7 +6,7 @@
 
 	interface Props {
 		isHovered: boolean;
-		onEdit?: () => void;
+		onEdit: () => void;
 	}
 
 	let { isHovered, onEdit }: Props = $props();
@@ -19,7 +19,7 @@
 	<Tooltip>
 		<TooltipTrigger>
 			<Button
-				onclick={() => onEdit?.()}
+				onclick={onEdit}
 				class="h-6 w-6"
 				variant="ghost"
 				size="icon-sm"

--- a/apps/frontend/src/lib/components/UserMessageActions.svelte
+++ b/apps/frontend/src/lib/components/UserMessageActions.svelte
@@ -1,17 +1,15 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import { Pencil } from '@lucide/svelte';
-	import type { BaseMessage } from '$lib/langgraph/types';
 	import * as m from '$lib/paraglide/messages.js';
 	import { Tooltip, TooltipTrigger, TooltipContent } from '$lib/components/ui/tooltip/index.js';
 
 	interface Props {
-		message: BaseMessage;
 		isHovered: boolean;
-		onEdit?: (message: BaseMessage) => void;
+		onEdit?: () => void;
 	}
 
-	let { message, isHovered, onEdit }: Props = $props();
+	let { isHovered, onEdit }: Props = $props();
 </script>
 
 <div
@@ -21,18 +19,17 @@
 	<Tooltip>
 		<TooltipTrigger>
 			<Button
-				onclick={() => onEdit?.(message)}
+				onclick={() => onEdit?.()}
 				class="h-6 w-6"
 				variant="ghost"
 				size="icon-sm"
 				title={m.message_edit()}
-				disabled
 			>
 				<Pencil size={16} />
 			</Button>
 		</TooltipTrigger>
 		<TooltipContent>
-			{m.coming_soon()}
+			{m.message_edit()}
 		</TooltipContent>
 	</Tooltip>
 </div>

--- a/apps/frontend/src/lib/components/UserMessageActions.svelte.test.ts
+++ b/apps/frontend/src/lib/components/UserMessageActions.svelte.test.ts
@@ -5,7 +5,7 @@ import { renderWithProviders } from './__tests__/render';
 import UserMessageActions from './UserMessageActions.svelte';
 
 function renderComponent(overrides: Record<string, unknown> = {}) {
-	return renderWithProviders(UserMessageActions, { ...overrides });
+	return renderWithProviders(UserMessageActions, { onEdit: vi.fn(), ...overrides });
 }
 
 describe('UserMessageActions', () => {

--- a/apps/frontend/src/lib/components/UserMessageActions.svelte.test.ts
+++ b/apps/frontend/src/lib/components/UserMessageActions.svelte.test.ts
@@ -1,12 +1,11 @@
-import { describe, test, expect, beforeEach } from 'vitest';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { screen } from '@testing-library/svelte';
+import { userEvent } from '@testing-library/user-event';
 import { renderWithProviders } from './__tests__/render';
 import UserMessageActions from './UserMessageActions.svelte';
-import { aUserMessage } from './__tests__/fixtures';
 
 function renderComponent(overrides: Record<string, unknown> = {}) {
-	const message = aUserMessage();
-	return renderWithProviders(UserMessageActions, { message, ...overrides });
+	return renderWithProviders(UserMessageActions, { ...overrides });
 }
 
 describe('UserMessageActions', () => {
@@ -19,9 +18,9 @@ describe('UserMessageActions', () => {
 			expect(screen.getByTitle(/edit/i)).toBeInTheDocument();
 		});
 
-		test('edit button is disabled (coming soon)', () => {
+		test('edit button is enabled', () => {
 			const button = screen.getByTitle(/edit/i) as HTMLButtonElement;
-			expect(button).toBeDisabled();
+			expect(button).not.toBeDisabled();
 		});
 	});
 
@@ -32,6 +31,18 @@ describe('UserMessageActions', () => {
 
 		test('hides the edit button when not hovered', () => {
 			expect(screen.getByTitle(/edit/i)).not.toBeVisible();
+		});
+	});
+
+	describe('when edit button is clicked', () => {
+		test('calls onEdit callback', async () => {
+			const user = userEvent.setup();
+			const onEdit = vi.fn();
+			renderComponent({ isHovered: true, onEdit });
+
+			await user.click(screen.getByTitle(/edit/i));
+
+			expect(onEdit).toHaveBeenCalledOnce();
 		});
 	});
 });

--- a/apps/frontend/src/lib/components/UserMessageEdit.svelte
+++ b/apps/frontend/src/lib/components/UserMessageEdit.svelte
@@ -12,7 +12,7 @@
 	let { value = $bindable(), onConfirm, onCancel }: Props = $props();
 
 	function handleKeydown(e: KeyboardEvent) {
-		if (e.key === 'Enter' && !e.shiftKey) {
+		if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
 			e.preventDefault();
 			onConfirm();
 		}

--- a/apps/frontend/src/lib/components/UserMessageEdit.svelte
+++ b/apps/frontend/src/lib/components/UserMessageEdit.svelte
@@ -1,21 +1,14 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
+	import { Textarea } from '$lib/components/ui/textarea';
 
 	interface Props {
 		value: string;
-		rows: number;
-		textareaRef?: HTMLTextAreaElement;
 		onConfirm: () => void;
 		onCancel: () => void;
 	}
 
-	let {
-		value = $bindable(),
-		rows,
-		textareaRef = $bindable(),
-		onConfirm,
-		onCancel
-	}: Props = $props();
+	let { value = $bindable(), onConfirm, onCancel }: Props = $props();
 
 	function handleKeydown(e: KeyboardEvent) {
 		if (e.key === 'Enter' && !e.shiftKey) {
@@ -29,13 +22,12 @@
 </script>
 
 <div class="flex w-full flex-col gap-1.5">
-	<textarea
-		bind:this={textareaRef}
+	<Textarea
 		bind:value
 		onkeydown={handleKeydown}
-		{rows}
-		class="bg-foreground text-background focus:ring-ring w-full resize-none rounded-xl px-6 py-6 text-sm shadow-sm focus:ring-2 focus:outline-none"
-	></textarea>
+		autofocus
+		class="bg-foreground dark:bg-foreground text-background ring-2 ring-blue-500 focus-visible:ring-blue-500 min-h-0 resize-none rounded-xl border-0 px-6 py-6 text-sm shadow-sm"
+	/>
 	<div class="flex justify-end gap-1.5">
 		<button
 			type="button"

--- a/apps/frontend/src/lib/components/UserMessageEdit.svelte
+++ b/apps/frontend/src/lib/components/UserMessageEdit.svelte
@@ -26,7 +26,7 @@
 		bind:value
 		onkeydown={handleKeydown}
 		autofocus
-		class="bg-foreground dark:bg-foreground text-background ring-2 ring-blue-500 focus-visible:ring-blue-500 min-h-0 resize-none rounded-xl border-0 px-6 py-6 text-sm shadow-sm"
+		class="bg-foreground dark:bg-foreground text-background min-h-0 resize-none rounded-xl border-0 px-6 py-6 text-sm shadow-sm ring-2 ring-blue-500 focus-visible:ring-blue-500"
 	/>
 	<div class="flex justify-end gap-1.5">
 		<button

--- a/apps/frontend/src/lib/components/UserMessageEdit.svelte
+++ b/apps/frontend/src/lib/components/UserMessageEdit.svelte
@@ -27,6 +27,7 @@
 		bind:value
 		onkeydown={handleKeydown}
 		autofocus
+		aria-label={m.message_edit()}
 		class="bg-foreground dark:bg-foreground text-background min-h-0 resize-none rounded-xl border-0 px-6 py-6 text-sm shadow-sm ring-2 ring-blue-500 focus-visible:ring-blue-500"
 	/>
 	<div class="flex justify-end gap-1.5">

--- a/apps/frontend/src/lib/components/UserMessageEdit.svelte
+++ b/apps/frontend/src/lib/components/UserMessageEdit.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import * as m from '$lib/paraglide/messages.js';
 	import { Textarea } from '$lib/components/ui/textarea';
+	import { Button } from '$lib/components/ui/button';
 
 	interface Props {
 		value: string;
@@ -29,19 +30,7 @@
 		class="bg-foreground dark:bg-foreground text-background min-h-0 resize-none rounded-xl border-0 px-6 py-6 text-sm shadow-sm ring-2 ring-blue-500 focus-visible:ring-blue-500"
 	/>
 	<div class="flex justify-end gap-1.5">
-		<button
-			type="button"
-			onclick={onCancel}
-			class="text-muted-foreground hover:bg-muted rounded px-2.5 py-1 text-xs transition-colors"
-		>
-			{m.cancel()}
-		</button>
-		<button
-			type="button"
-			onclick={onConfirm}
-			class="bg-foreground text-background rounded px-2.5 py-1 text-xs font-medium transition-colors"
-		>
-			{m.save_and_send()}
-		</button>
+		<Button variant="ghost" size="sm" onclick={onCancel}>{m.cancel()}</Button>
+		<Button variant="secondary" size="sm" onclick={onConfirm}>{m.save_and_send()}</Button>
 	</div>
 </div>

--- a/apps/frontend/src/lib/components/UserMessageEdit.svelte
+++ b/apps/frontend/src/lib/components/UserMessageEdit.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages.js';
+
+	interface Props {
+		value: string;
+		rows: number;
+		textareaRef?: HTMLTextAreaElement;
+		onConfirm: () => void;
+		onCancel: () => void;
+	}
+
+	let {
+		value = $bindable(),
+		rows,
+		textareaRef = $bindable(),
+		onConfirm,
+		onCancel
+	}: Props = $props();
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter' && !e.shiftKey) {
+			e.preventDefault();
+			onConfirm();
+		}
+		if (e.key === 'Escape') {
+			onCancel();
+		}
+	}
+</script>
+
+<div class="flex w-full flex-col gap-1.5">
+	<textarea
+		bind:this={textareaRef}
+		bind:value
+		onkeydown={handleKeydown}
+		{rows}
+		class="bg-foreground text-background focus:ring-ring w-full resize-none rounded-xl px-6 py-6 text-sm shadow-sm focus:ring-2 focus:outline-none"
+	></textarea>
+	<div class="flex justify-end gap-1.5">
+		<button
+			type="button"
+			onclick={onCancel}
+			class="text-muted-foreground hover:bg-muted rounded px-2.5 py-1 text-xs transition-colors"
+		>
+			{m.cancel()}
+		</button>
+		<button
+			type="button"
+			onclick={onConfirm}
+			class="bg-foreground text-background rounded px-2.5 py-1 text-xs font-medium transition-colors"
+		>
+			{m.save_and_send()}
+		</button>
+	</div>
+</div>

--- a/apps/frontend/src/lib/components/__tests__/mockUseStream.svelte.ts
+++ b/apps/frontend/src/lib/components/__tests__/mockUseStream.svelte.ts
@@ -3,6 +3,7 @@
  * components re-render when helpers mutate it in tests.
  */
 
+// Loose function type for mock callbacks that don't care about their arguments
 type AnyFn = (...args: unknown[]) => unknown;
 
 export const mockStreamCallbacks: {

--- a/apps/frontend/src/lib/components/__tests__/mockUseStream.svelte.ts
+++ b/apps/frontend/src/lib/components/__tests__/mockUseStream.svelte.ts
@@ -3,12 +3,16 @@
  * components re-render when helpers mutate it in tests.
  */
 
-export const mockStreamCallbacks = {
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	submit: (...args: unknown[]) => {},
+type AnyFn = (...args: unknown[]) => unknown;
+
+export const mockStreamCallbacks: {
+	submit: AnyFn;
+	stop: () => void;
+	getMessagesMetadata: AnyFn;
+} = {
+	submit: () => {},
 	stop: () => {},
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	getMessagesMetadata: (...args: unknown[]) => undefined as unknown
+	getMessagesMetadata: () => undefined
 };
 
 let _messages = $state<Record<string, unknown>[]>([]);

--- a/apps/frontend/src/lib/components/__tests__/mockUseStream.svelte.ts
+++ b/apps/frontend/src/lib/components/__tests__/mockUseStream.svelte.ts
@@ -4,8 +4,11 @@
  */
 
 export const mockStreamCallbacks = {
-	submit: () => {},
-	stop: () => {}
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	submit: (...args: unknown[]) => {},
+	stop: () => {},
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	getMessagesMetadata: (...args: unknown[]) => undefined as unknown
 };
 
 let _messages = $state<Record<string, unknown>[]>([]);
@@ -27,6 +30,9 @@ export const mockStream = {
 	},
 	get stop() {
 		return mockStreamCallbacks.stop;
+	},
+	get getMessagesMetadata() {
+		return mockStreamCallbacks.getMessagesMetadata;
 	}
 };
 
@@ -48,4 +54,5 @@ export function resetMock() {
 	_error = null;
 	mockStreamCallbacks.submit = () => {};
 	mockStreamCallbacks.stop = () => {};
+	mockStreamCallbacks.getMessagesMetadata = () => undefined;
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -67,7 +67,7 @@ export default defineConfig({
 			name: 'frontend',
 			command: 'moon frontend:serve-e2e',
 			timeout: 120000,
-			stdout: 'ignore',
+			stdout: 'pipe',
 			stderr: 'pipe',
 			gracefulShutdown: { signal: 'SIGINT', timeout: 1500 },
 			wait: {

--- a/e2e/src/chat.spec.ts
+++ b/e2e/src/chat.spec.ts
@@ -93,7 +93,7 @@ test.describe('Edit message', () => {
 		await editTextarea.press('Enter');
 
 		// A new AI response should appear
-		await expect(page.getByText('Edited question')).toBeVisible();
+		await expect(page.getByText('Edited question').first()).toBeVisible();
 	});
 });
 

--- a/e2e/src/chat.spec.ts
+++ b/e2e/src/chat.spec.ts
@@ -32,34 +32,34 @@ test.describe('Edit message', () => {
 		await chat.textInput.press('Enter');
 
 		// Wait for the user message to appear
-		const userMessage = page.getByText('Hello').first();
-		await expect(userMessage).toBeVisible();
+		const userMessageGroup = page.getByRole('group').filter({ has: page.getByText('Hello') }).first();
+		await expect(userMessageGroup).toBeVisible();
 
-		// Hover to reveal the edit button
-		await userMessage.hover();
-		const editButton = page.getByTitle(/edit/i);
-		await expect(editButton).toBeVisible();
-		await editButton.click();
+		// Hover to reveal the edit button and click it
+		await userMessageGroup.hover();
+		await userMessageGroup.getByTitle(/edit/i).click();
 
-		const textarea = page.getByRole('textbox').nth(1);
-		await expect(textarea).toBeVisible();
-		await expect(textarea).toHaveValue('Hello');
+		// The edit textarea appears above the chat input, so it is nth(0)
+		const editTextarea = page.getByRole('textbox').nth(0);
+		await expect(editTextarea).toBeVisible();
+		await expect(editTextarea).toHaveValue('Hello');
 	});
 
 	test('pressing Escape cancels editing', async ({ page, chat }) => {
 		await chat.textInput.fill('Hello');
 		await chat.textInput.press('Enter');
 
-		const userMessage = page.getByText('Hello').first();
-		await expect(userMessage).toBeVisible();
+		const userMessageGroup = page.getByRole('group').filter({ has: page.getByText('Hello') }).first();
+		await expect(userMessageGroup).toBeVisible();
 
-		await userMessage.hover();
-		await page.getByTitle(/edit/i).click();
+		await userMessageGroup.hover();
+		await userMessageGroup.getByTitle(/edit/i).click();
 
 		await page.keyboard.press('Escape');
 
+		// Edit textarea is removed; only the chat input textbox remains
 		await expect(page.getByText('Hello').first()).toBeVisible();
-		await expect(page.getByRole('textbox').nth(1)).not.toBeVisible();
+		await expect(page.getByRole('textbox')).toHaveCount(1);
 	});
 
 	test('editing and submitting branches the conversation', async ({ page, chat }) => {
@@ -67,21 +67,21 @@ test.describe('Edit message', () => {
 		await chat.textInput.press('Enter');
 
 		// Wait for AI response
-		const aiMessage = page
-			.getByRole('group')
-			.filter({ has: page.locator('.prose') })
-			.first();
+		const aiMessage = page.getByRole('group').filter({ has: page.locator('.prose') }).first();
 		await expect(aiMessage).toBeVisible();
 		await expect(aiMessage).not.toBeEmpty();
 
 		// Edit the user message
-		const userMessage = page.getByText('First question').first();
-		await userMessage.hover();
-		await page.getByTitle(/edit/i).click();
+		const userMessageGroup = page
+			.getByRole('group')
+			.filter({ has: page.getByText('First question') })
+			.first();
+		await userMessageGroup.hover();
+		await userMessageGroup.getByTitle(/edit/i).click();
 
-		const textarea = page.getByRole('textbox').nth(1);
-		await textarea.fill('Edited question');
-		await textarea.press('Enter');
+		const editTextarea = page.getByRole('textbox').nth(0);
+		await editTextarea.fill('Edited question');
+		await editTextarea.press('Enter');
 
 		// A new AI response should appear
 		await expect(page.getByText('Edited question')).toBeVisible();

--- a/e2e/src/chat.spec.ts
+++ b/e2e/src/chat.spec.ts
@@ -20,6 +20,74 @@ test('user can send a message and receive an AI response', async ({ page, chat }
 	await expect(aiMessage).not.toBeEmpty();
 });
 
+test.describe('Edit message', () => {
+	test.beforeEach(async ({ page }) => {
+		await authenticateUser(page);
+		await page.goto('/chat/');
+		await page.waitForURL(/\/chat\/[\w-]+/);
+	});
+
+	test('edit button opens a textarea with original message text', async ({ page, chat }) => {
+		await chat.textInput.fill('Hello');
+		await chat.textInput.press('Enter');
+
+		// Wait for the user message to appear
+		const userMessage = page.getByText('Hello').first();
+		await expect(userMessage).toBeVisible();
+
+		// Hover to reveal the edit button
+		await userMessage.hover();
+		const editButton = page.getByTitle(/edit/i);
+		await expect(editButton).toBeVisible();
+		await editButton.click();
+
+		const textarea = page.getByRole('textbox').nth(1);
+		await expect(textarea).toBeVisible();
+		await expect(textarea).toHaveValue('Hello');
+	});
+
+	test('pressing Escape cancels editing', async ({ page, chat }) => {
+		await chat.textInput.fill('Hello');
+		await chat.textInput.press('Enter');
+
+		const userMessage = page.getByText('Hello').first();
+		await expect(userMessage).toBeVisible();
+
+		await userMessage.hover();
+		await page.getByTitle(/edit/i).click();
+
+		await page.keyboard.press('Escape');
+
+		await expect(page.getByText('Hello').first()).toBeVisible();
+		await expect(page.getByRole('textbox').nth(1)).not.toBeVisible();
+	});
+
+	test('editing and submitting branches the conversation', async ({ page, chat }) => {
+		await chat.textInput.fill('First question');
+		await chat.textInput.press('Enter');
+
+		// Wait for AI response
+		const aiMessage = page
+			.getByRole('group')
+			.filter({ has: page.locator('.prose') })
+			.first();
+		await expect(aiMessage).toBeVisible();
+		await expect(aiMessage).not.toBeEmpty();
+
+		// Edit the user message
+		const userMessage = page.getByText('First question').first();
+		await userMessage.hover();
+		await page.getByTitle(/edit/i).click();
+
+		const textarea = page.getByRole('textbox').nth(1);
+		await textarea.fill('Edited question');
+		await textarea.press('Enter');
+
+		// A new AI response should appear
+		await expect(page.getByText('Edited question')).toBeVisible();
+	});
+});
+
 test.describe('Cancellation', () => {
 	test.beforeEach(async ({ page }) => {
 		await authenticateUser(page);

--- a/e2e/src/chat.spec.ts
+++ b/e2e/src/chat.spec.ts
@@ -69,10 +69,13 @@ test.describe('Edit message', () => {
 	});
 
 	test('editing and submitting branches the conversation', async ({ page, chat }) => {
-		await chat.textInput.fill('First question');
+		const messageId = randomUUID();
+		const originalQuestion = `First question ${messageId}`;
+		const editedQuestion = `Edited question ${messageId}`;
+
+		await chat.textInput.fill(originalQuestion);
 		await chat.textInput.press('Enter');
 
-		// Wait for AI response
 		const aiMessage = page
 			.getByRole('group')
 			.filter({ has: page.locator('.prose') })
@@ -83,17 +86,21 @@ test.describe('Edit message', () => {
 		// Edit the user message
 		const userMessageGroup = page
 			.getByRole('group')
-			.filter({ has: page.getByText('First question') })
+			.filter({ has: page.getByText(originalQuestion) })
 			.first();
 		await userMessageGroup.hover();
 		await userMessageGroup.getByTitle(/edit/i).click();
 
 		const editTextarea = page.getByRole('textbox').nth(0);
-		await editTextarea.fill('Edited question');
+		await editTextarea.fill(editedQuestion);
 		await editTextarea.press('Enter');
 
-		// A new AI response should appear
-		await expect(page.getByText('Edited question').first()).toBeVisible();
+		// Verify the edited prompt is shown and a response was regenerated.
+		// We don't assert the response text changed — the LLM may produce the
+		// same output at low temperature — we only assert it completed.
+		await expect(page.getByText(editedQuestion).first()).toBeVisible();
+		await expect(aiMessage).toBeVisible();
+		await expect(aiMessage).not.toBeEmpty();
 	});
 });
 

--- a/e2e/src/chat.spec.ts
+++ b/e2e/src/chat.spec.ts
@@ -32,7 +32,10 @@ test.describe('Edit message', () => {
 		await chat.textInput.press('Enter');
 
 		// Wait for the user message to appear
-		const userMessageGroup = page.getByRole('group').filter({ has: page.getByText('Hello') }).first();
+		const userMessageGroup = page
+			.getByRole('group')
+			.filter({ has: page.getByText('Hello') })
+			.first();
 		await expect(userMessageGroup).toBeVisible();
 
 		// Hover to reveal the edit button and click it
@@ -49,7 +52,10 @@ test.describe('Edit message', () => {
 		await chat.textInput.fill('Hello');
 		await chat.textInput.press('Enter');
 
-		const userMessageGroup = page.getByRole('group').filter({ has: page.getByText('Hello') }).first();
+		const userMessageGroup = page
+			.getByRole('group')
+			.filter({ has: page.getByText('Hello') })
+			.first();
 		await expect(userMessageGroup).toBeVisible();
 
 		await userMessageGroup.hover();
@@ -67,7 +73,10 @@ test.describe('Edit message', () => {
 		await chat.textInput.press('Enter');
 
 		// Wait for AI response
-		const aiMessage = page.getByRole('group').filter({ has: page.locator('.prose') }).first();
+		const aiMessage = page
+			.getByRole('group')
+			.filter({ has: page.locator('.prose') })
+			.first();
 		await expect(aiMessage).toBeVisible();
 		await expect(aiMessage).not.toBeEmpty();
 


### PR DESCRIPTION
PR attempts to enable the user msg edit functionality. Idea here is to provide a single threaded conversation with no frontend branching logic. User can edit the msg and it will be taken directly to new updated branch. 

Also, extends UI and e2e tests

**Side-quest -** Attempts to solve the flakiness in the CI e2e tests, by updating playwright config.  
**Side-quest -** Extends guard in ChatInput against false enter when isComposing is true. Extending support to language with IME input - Japanese/Chinese/Korean
