### PR TITLE
Uncorrupt moon build cache (split SvelteKit version hash) - fixes E2E on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   ci-job:
     name: "CI Job"
     runs-on: "ubuntu-latest"
+    timeout-minutes: 30
     permissions:
       contents: read       # checkout
       checks: write        # run-report-action
@@ -30,11 +31,7 @@ jobs:
         with:
           cache-base: main
           auto-install: true
-      - uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          command: "moon ci --color"
+      - run: moon ci --color
       - uses: moonrepo/run-report-action@v1
         if: success() || failure()
         with:

--- a/apps/backend/moon.yml
+++ b/apps/backend/moon.yml
@@ -53,6 +53,7 @@ tasks:
     preset: "server"
     env:
       NO_COLOR: "true"
+      MOCK_STREAM_DELAY: "0.05"
   oidc-mock:
     command: "oidc-provider-mock --port 8080 --host localhost --user test-user 2>&1"
     preset: "server"

--- a/apps/frontend/moon.yml
+++ b/apps/frontend/moon.yml
@@ -21,15 +21,20 @@ fileGroups:
 tags: ['vite', 'vitest', 'sveltekit']
 
 tasks:
+  clean:
+    command: 'rm -rf build src/lib/paraglide'
+    options:
+      cache: false
+
   build:
+    deps:
+      - clean
     inputs:
       - '@group(sources)'
       - '@group(messages)'
     outputs:
       - 'build'
       - 'src/lib/paraglide'
-    options:
-      retryCount: 1
 
   check:
     deps:

--- a/apps/frontend/svelte.config.js
+++ b/apps/frontend/svelte.config.js
@@ -1,10 +1,17 @@
 import adapter from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
+// Pin the SvelteKit version to moon's task hash so client and server always agree on
+// __sveltekit_<hash>. moon injects MOON_TASK_HASH and keeps it stable across retries and
+// machines for identical inputs. Falls back to SvelteKit's Date.now() default when built
+// outside moon (a standalone single-process build is internally consistent anyway).
+const version = process.env.MOON_TASK_HASH ? { name: process.env.MOON_TASK_HASH } : undefined;
+
 const config = {
 	preprocess: vitePreprocess(),
 	kit: {
 		adapter: adapter(),
+		...(version ? { version } : {}),
 		alias: {
 			async_hooks: './src/lib/async_hooks_mock.ts'
 		}

--- a/e2e/src/chat.spec.ts
+++ b/e2e/src/chat.spec.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { test, expect } from './fixtures/test';
 import { authenticateUser } from './fixtures/auth';
+import { LANGGRAPH_CONFIG } from './fixtures/backend';
 
 test('user can send a message and receive an AI response', async ({ page, chat }) => {
 	await authenticateUser(page);
@@ -82,6 +83,8 @@ test.describe('Edit message', () => {
 			.first();
 		await expect(aiMessage).toBeVisible();
 		await expect(aiMessage).not.toBeEmpty();
+		// Wait for streaming to finish — edit button is disabled while streaming.
+		await expect(chat.textInput).toBeEnabled();
 
 		// Edit the user message
 		const userMessageGroup = page
@@ -143,14 +146,24 @@ test.describe('Cancellation', () => {
 		page,
 		chat
 	}) => {
-		// Long unique input — ai-mock echoes it back character-by-character with a
-		// 10ms delay per chunk, giving a ~5s streaming window to click stop.
+		// Long unique input — ai-mock echoes it back with MOCK_STREAM_DELAY (50ms) per
+		// chunk, giving a wide streaming window for the cancel to land server-side.
 		const testInput = randomUUID().replace(/-/g, '').repeat(16); // ~512 hex chars
 		const partialEcho = testInput.slice(0, 20); // Wait for these before stopping
-		// The tail will only appear if the LangGraph run completed server-side.
-		// Aborting the stream should also cancel the run; if it doesn't (the bug),
-		// the backend finishes the full echo and stores it in the thread state.
+		// tailEcho only appears in thread state if the LangGraph run ran to completion.
 		const tailEcho = testInput.slice(-30);
+
+		// Intercept LangGraph requests to capture the Bearer token before we need it
+		// for direct API calls. Registered before the message is sent so the stream
+		// request (which fires on Enter) is guaranteed to be intercepted.
+		let capturedToken: string | null = null;
+		await page.route(`${LANGGRAPH_CONFIG.apiUrl}/**`, async (route) => {
+			const authHeader = route.request().headers()['authorization'];
+			if (authHeader?.startsWith('Bearer ')) {
+				capturedToken = authHeader.substring(7);
+			}
+			await route.continue();
+		});
 
 		await chat.textInput.fill(testInput);
 		await chat.textInput.press('Enter');
@@ -164,19 +177,48 @@ test.describe('Cancellation', () => {
 		// Confirm client-side streaming has stopped
 		await expect(chat.textInput).toBeEnabled();
 
-		// Allow time for the server-side run to complete if it wasn't cancelled.
-		// This must happen BEFORE reload: the frontend fetches thread state once on
-		// navigation, so we need the run to finish writing to the thread first.
-		await page.waitForTimeout(4000);
+		// By now streaming has started and stopped, so the token must be set
+		expect(capturedToken).toBeTruthy();
+		const threadId = new URL(page.url()).pathname.split('/').at(-1)!;
+		const apiUrl = LANGGRAPH_CONFIG.apiUrl;
+		const headers = { Authorization: `Bearer ${capturedToken!}` };
 
-		// Reload the page — fetches fresh thread state from the LangGraph server.
-		// If the run was NOT cancelled server-side, the backend will have finished
-		// and stored the full response; after reload the full message becomes visible.
-		await page.reload();
+		// Poll until the run is no longer active (pending/running → success/interrupted/…).
+		// This replaces the fixed waitForTimeout(4000): we wait exactly as long as needed.
+		const deadline = Date.now() + 15_000;
+		let isActive = true;
+		while (Date.now() < deadline) {
+			const runsRes = await page.request.get(`${apiUrl}/threads/${threadId}/runs`, { headers });
+			expect(runsRes.ok()).toBeTruthy();
+			const runs = (await runsRes.json()) as Array<{ status: string }>;
+			isActive = runs.some((r) => r.status === 'pending' || r.status === 'running');
+			if (!isActive) break;
+			await page.waitForTimeout(200);
+		}
+		// Fail loudly if the deadline expired while the run was still active — otherwise
+		// the state read below could race and the test would pass on incomplete data.
+		expect(isActive).toBe(false);
 
-		// The tail of the echo must NOT appear — the cancelled run should have
-		// committed only the partial response received before the stop.
-		// This assertion FAILS when the bug is present (full echo is in thread state).
-		await expect(page.getByText(tailEcho, { exact: false })).not.toBeVisible();
+		// Read the committed thread state directly — no page reload needed.
+		const stateRes = await page.request.get(`${apiUrl}/threads/${threadId}/state`, { headers });
+		expect(stateRes.ok()).toBeTruthy();
+		const state = await stateRes.json();
+		const messages = state.values?.messages as
+			| Array<{ type: string; content: unknown }>
+			| undefined;
+
+		// Positive guard: our human message must exist in state, confirming the run fired.
+		// partialEcho is unique (randomUUID per run), so even if the thread has accumulated
+		// history from prior test iterations, we'll find exactly our message.
+		const hasOurMessage =
+			messages?.some((m) => m.type === 'human' && String(m.content).includes(partialEcho)) ?? false;
+		expect(hasOurMessage).toBe(true);
+
+		// Main assertion: the cancelled run must NOT have committed the full echo.
+		// tailEcho only appears when the model node ran to completion before cancel landed.
+		const aiContent = (messages?.filter((m) => m.type === 'ai') ?? [])
+			.map((m) => String(m.content))
+			.join('');
+		expect(aiContent).not.toContain(tailEcho);
 	});
 });


### PR DESCRIPTION
## Summary

- **Root fix (`svelte.config.js`):** Pin `kit.version.name` to `MOON_TASK_HASH` so client and server always stamp the same `__sveltekit_<hash>`. Without this, SvelteKit defaults to `Date.now()` per OS process — two separate build processes produce two different hashes, making the cached artifact internally inconsistent and causing `TypeError: Cannot read properties of undefined (reading 'env')` at hydration.
- **Belt-and-suspenders (`moon.yml`):** Add a non-cached `clean` task that wipes `build/` and `src/lib/paraglide/` before every build, and make `build` depend on it. Prevents stale content-hashed chunks from a prior process from layering into a new artifact under moon's additive file-copy behavior.
- **CI hardening (`ci.yml`):** Replace `nick-fields/retry@v3` (max 3 attempts) with a plain `run: moon ci --color`. The retry wrapper was counter-productive: retries hydrated the corrupt cache rather than rebuilding, and masked real E2E flakiness.

## E2E test hardening (commits `3dc66db`, `a98131f`, `388170f`, `ac0f56a`)

Removing the retry wrapper exposed genuine test flakiness — fixed in follow-up commits:

- **`MOCK_STREAM_DELAY` raised 10ms → 50ms** (`apps/backend/moon.yml` `ai-mock-e2e` env): widens the streaming window so the server-side cancel reliably lands before the node finishes.
- **Server-side cancellation test rewritten:** capture Bearer token via `page.route`, poll `GET /threads/{id}/runs` until terminal, assert on committed thread state. No more `waitForTimeout`, no reload.
- **Hardened polling loop** (`ac0f56a`): declare `isActive` outside the loop and `expect(isActive).toBe(false)` after it exits — deadline expiry now fails loudly instead of silently racing to read incomplete state. Also assert `runsRes.ok()` and `stateRes.ok()` before parsing JSON.
- **Edit-test gate** (`388170f`): wait for `chat.textInput` to be enabled before clicking edit — the slower mock surfaced that the edit button is disabled mid-stream.
- **CI job timeout** (`ac0f56a`): add `timeout-minutes: 30` to `ci-job` — restores an explicit cap after `nick-fields/retry` (which had `timeout_minutes: 20`) was removed.

## Why this happened

Two ingredients were needed for corruption:
1. SvelteKit's default `version.name = Date.now()` — each build process gets a unique hash, so client and server chunks from two processes disagree.
2. moon never cleans outputs before a task, and its cache key is inputs-only — it trusts the first exit-0 result and uploads the tarball; every subsequent PR restores it, spreading corruption repo-wide.

The `MOON_TASK_HASH` pin makes the hash deterministic and identical across retries and machines for the same inputs. It also changes a `**/*.config.*` build input, so the poisoned cached tarball is immediately orphaned — no manual cache purge required.

## Test plan

- [ ] CI runs `moon ci` once (no retry attempts visible in the job log)
- [ ] E2E tests pass — no `TypeError: Cannot read properties of undefined (reading 'env')` in browser console, `body.started` is set on page load
- [ ] Confirm `build/client` and `build/server` carry the same `__sveltekit_<hash>` / `version_hash` after a fresh build
- [ ] All 6 E2E tests green without the retry wrapper
- [ ] Cancellation test: `--repeat-each=10` shows no false-negative passes (poll loop asserts terminal state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #253.