### PR TITLE
Run E2E in dedicated Playwright Docker container job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,6 @@ jobs:
         with:
           token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
           command: complete
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v5
-        if: failure()
-        with:
-          name: playwright-report
-          path: e2e/playwright-report/
-          retention-days: 14
-
   build:
     name: "Docker Build"
     runs-on: ubuntu-latest
@@ -108,10 +100,45 @@ jobs:
           # No progress indicators for downloads
           BUILDKIT_PROGRESS: plain
 
+  e2e:
+    name: "E2E"
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.1-noble  # keep in sync with e2e/package.json @playwright/test
+      options: --init --ipc=host
+    permissions:
+      contents: read   # checkout
+      actions: write   # setup-toolchain cache
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Install OS prerequisites for proto toolchain
+        run: apt-get update && apt-get install -y --no-install-recommends unzip xz-utils
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: moonrepo/setup-toolchain@v0
+        with:
+          cache-base: main
+          auto-install: true
+      - name: Run E2E tests
+        run: moon e2e:test --color
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v5
+        if: failure()
+        with:
+          name: playwright-report
+          path: |
+            e2e/playwright-report/
+            e2e/test-results/
+          retention-days: 14
+
   ci:
     name: "CI"
     runs-on: ubuntu-latest
-    needs: [ci-job, build]
+    needs: [ci-job, build, e2e]
     if: always()
     steps:
       - run: ${{!contains(needs.*.result, 'failure')}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,9 @@ jobs:
   e2e:
     name: "E2E"
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     container:
-      image: mcr.microsoft.com/playwright:v1.58.1-noble  # keep in sync with e2e/package.json @playwright/test
+      image: mcr.microsoft.com/playwright:v1.58.1-noble  # keep in sync with @playwright/test in e2e/pnpm-lock.yaml
       options: --init --ipc=host
     permissions:
       contents: read   # checkout
@@ -141,7 +142,7 @@ jobs:
     needs: [ci-job, build, e2e]
     if: always()
     steps:
-      - run: ${{!contains(needs.*.result, 'failure')}}
+      - run: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
 
   deploy:
     name: "Deploy"

--- a/e2e/moon.yml
+++ b/e2e/moon.yml
@@ -79,7 +79,7 @@ tasks:
       - '@group(sources)'
       - '$CI'
     options:
-      runInCI: false   # run only in the dedicated container E2E job (see .github/workflows/ci.yml)
+      runInCI: false # run only in the dedicated container E2E job (see .github/workflows/ci.yml)
 
   test-ui:
     extends: test

--- a/e2e/moon.yml
+++ b/e2e/moon.yml
@@ -78,6 +78,8 @@ tasks:
     inputs:
       - '@group(sources)'
       - '$CI'
+    options:
+      runInCI: false   # run only in the dedicated container E2E job (see .github/workflows/ci.yml)
 
   test-ui:
     extends: test


### PR DESCRIPTION
## Summary

- Adds a new `e2e` GHA job that runs inside `mcr.microsoft.com/playwright:v1.58.1-noble`, skipping the Chromium download entirely via `PLAYWRIGHT_BROWSERS_PATH=/ms-playwright`
- Sets `runInCI: false` on the `e2e:test` moon task so `moon ci` in the main `ci-job` no longer runs E2E (no double-execution)
- The new job runs **in parallel** with `ci-job` and `build`; the `ci` gate now requires all three to pass
- Playwright report artifact (`e2e/playwright-report/` + `e2e/test-results/`) is uploaded on failure from the new job

## Test plan

- [ ] Check `ci-job` log: `moon ci` output no longer contains `e2e:test`
- [ ] Check `e2e` job log: container is `playwright:v1.58.1-noble`; `playwright install` reports browser already present (no Chromium download); all four webServers report ready; tests pass
- [ ] Check `ci` gate waits on all three jobs and reflects the result correctly
- [ ] Failure path: confirm `playwright-report` artifact uploads when a spec fails

> **Maintenance note:** The image tag `v1.58.1-noble` must stay in sync with `@playwright/test` in `e2e/package.json`. Bump both together on a Playwright upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)